### PR TITLE
Fix/message batch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezcountdown/bootstrap/PluginBootstrap.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/bootstrap/PluginBootstrap.java
@@ -86,6 +86,9 @@ public final class PluginBootstrap {
         // register into registry
         registry.setCountdownManager(countdownManager);
         countdownManager.load();
+        int loadedCount = countdownManager.getCountdownCount();
+        long runningCount = countdownManager.getCountdowns().stream().filter(c -> c.isRunning()).count();
+        plugin.getLogger().info("Loaded " + loadedCount + " countdown(s) (" + runningCount + " running).");
 
         // GUI and input handlers
         ChatInputListener chatInput = new ChatInputListener(plugin);
@@ -221,6 +224,24 @@ public final class PluginBootstrap {
         }
 
         plugin.reloadConfig();
+
+        // Startup summary
+        StringBuilder displaySb = new StringBuilder();
+        for (DisplayType dt : defaults.displayTypes()) {
+            if (displaySb.length() > 0) displaySb.append(", ");
+            displaySb.append(dt.name());
+        }
+        String displayStr = displaySb.length() > 0 ? displaySb.toString() : "none";
+        StringBuilder integrationsSb = new StringBuilder();
+        if (expansion != null) integrationsSb.append("PlaceholderAPI");
+        long enabledWebhooks = discordWebhookConfig.getWebhooks().stream().filter(w -> w.enabled).count();
+        if (enabledWebhooks > 0) {
+            if (integrationsSb.length() > 0) integrationsSb.append(", ");
+            integrationsSb.append("Discord (").append(enabledWebhooks)
+                    .append(enabledWebhooks == 1 ? " webhook)" : " webhooks)");
+        }
+        plugin.getLogger().info("Displays: [" + displayStr + "] | Timezone: " + defaults.zoneId().getId()
+                + " | Integrations: " + (integrationsSb.length() > 0 ? integrationsSb : "none"));
 
         return registry;
     }

--- a/src/main/java/com/skyblockexp/ezcountdown/config/ConfigService.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/config/ConfigService.java
@@ -94,6 +94,16 @@ public final class ConfigService {
         return new DiscordWebhookConfig();
     }
 
+    public int loadBossbarRefreshTicks() {
+        int v = plugin.getConfig().getInt("display.refresh.bossbar-ticks", 1);
+        return Math.max(1, v);
+    }
+
+    public int loadScoreboardRefreshTicks() {
+        int v = plugin.getConfig().getInt("display.refresh.scoreboard-ticks", 1);
+        return Math.max(1, v);
+    }
+
     private void ensureResource(String name) {
         File file = new File(plugin.getDataFolder(), name);
         if (!file.exists()) plugin.saveResource(name, false);

--- a/src/main/java/com/skyblockexp/ezcountdown/display/DisplayHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/DisplayHandler.java
@@ -6,4 +6,24 @@ public interface DisplayHandler {
     void display(Countdown countdown, String message, long remainingSeconds);
     void clear(Countdown countdown);
     void clearAll();
+
+    /**
+     * Display the countdown within a batched render pass.
+     *
+     * <p>Handlers that render via the chat channel (i.e. that call
+     * {@code player.sendMessage()} — either directly or as a fallback) should
+     * override this method and route those calls through {@code batch.add()}
+     * instead. {@link MessageBatch#flush()} is called by {@link
+     * com.skyblockexp.ezcountdown.manager.DisplayManager} after all handlers
+     * have contributed to the batch, ensuring each player receives at most one
+     * chat message per countdown per tick regardless of how many display types
+     * are active.
+     *
+     * <p>The default implementation simply delegates to {@link #display} so that
+     * third-party implementations remain source- and binary-compatible without
+     * any changes.
+     */
+    default void displayBatched(Countdown countdown, String message, long remainingSeconds, MessageBatch batch) {
+        display(countdown, message, remainingSeconds);
+    }
 }

--- a/src/main/java/com/skyblockexp/ezcountdown/display/DisplayMessage.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/DisplayMessage.java
@@ -1,0 +1,11 @@
+package com.skyblockexp.ezcountdown.display;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import org.bukkit.entity.Player;
+
+/**
+ * Represents a pending chat message to be sent to a player for a specific countdown.
+ * Used by {@link MessageBatch} to deduplicate messages when multiple display types
+ * would otherwise each deliver the same text to the same player in the same tick.
+ */
+public record DisplayMessage(Player player, Countdown countdown, String message) {}

--- a/src/main/java/com/skyblockexp/ezcountdown/display/MessageBatch.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/MessageBatch.java
@@ -1,0 +1,55 @@
+package com.skyblockexp.ezcountdown.display;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import org.bukkit.entity.Player;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Collects outgoing chat-channel messages within a single display tick and
+ * deduplicates them before delivery.
+ *
+ * <p>When a countdown has multiple display types (e.g. CHAT, ACTION_BAR, TITLE),
+ * handlers that fall back to {@code player.sendMessage()} on legacy servers would
+ * otherwise each deliver the same text. By routing all such messages through this
+ * batch, each player receives at most one message per countdown per tick regardless
+ * of how many display types are configured.
+ *
+ * <p>Key: {@code (playerUUID, countdownName)} — one entry per player per countdown.
+ * Re-adding the same pair is a no-op (first-write wins, preserving message stability).
+ */
+public final class MessageBatch {
+
+    /** Composite key: player UUID + countdown name (lower-case). */
+    private record Key(UUID playerId, String countdownName) {}
+
+    private final Map<Key, DisplayMessage> entries = new LinkedHashMap<>();
+
+    /**
+     * Adds a pending message to the batch.
+     * If an entry for the same player + countdown already exists it is ignored.
+     */
+    public void add(Player player, Countdown countdown, String message) {
+        Key key = new Key(player.getUniqueId(), countdown.getName().toLowerCase(java.util.Locale.ROOT));
+        entries.putIfAbsent(key, new DisplayMessage(player, countdown, message));
+    }
+
+    /**
+     * Sends all deduplicated messages and clears the batch.
+     */
+    public void flush() {
+        for (DisplayMessage dm : entries.values()) {
+            try {
+                dm.player().sendMessage(dm.message());
+            } catch (Exception ignored) {}
+        }
+        entries.clear();
+    }
+
+    /** Returns the number of pending (unique) entries in this batch. */
+    public int size() {
+        return entries.size();
+    }
+}

--- a/src/main/java/com/skyblockexp/ezcountdown/display/actionbar/ActionBarDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/actionbar/ActionBarDisplay.java
@@ -2,6 +2,7 @@ package com.skyblockexp.ezcountdown.display.actionbar;
 
 import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.display.DisplayHandler;
+import com.skyblockexp.ezcountdown.display.MessageBatch;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -21,6 +22,27 @@ public class ActionBarDisplay implements DisplayHandler {
                                 net.md_5.bungee.api.chat.TextComponent.fromLegacyText(message));
                     } catch (NoClassDefFoundError ignored) {
                         player.sendMessage(message);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void displayBatched(Countdown countdown, String message, long remainingSeconds, MessageBatch batch) {
+        if (remainingSeconds <= 0L) return;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            String perm = countdown.getVisibilityPermission();
+            if (perm == null || perm.isBlank() || player.hasPermission(perm)) {
+                try {
+                    player.sendActionBar(message);
+                } catch (NoSuchMethodError err) {
+                    try {
+                        player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR,
+                                net.md_5.bungee.api.chat.TextComponent.fromLegacyText(message));
+                    } catch (NoClassDefFoundError ignored) {
+                        // Fall back to chat via batch to avoid duplicate messages
+                        batch.add(player, countdown, message);
                     }
                 }
             }

--- a/src/main/java/com/skyblockexp/ezcountdown/display/bossbar/BossBarDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/bossbar/BossBarDisplay.java
@@ -78,10 +78,17 @@ public class BossBarDisplay implements StackableDisplay {
     }
 
     private double calculateProgress(Countdown countdown, long remainingSeconds) {
-        long duration = countdown.getDurationSeconds();
-        if (duration <= 0L) return 1.0;
-        double progress = (double) remainingSeconds / (double) duration;
-        if (progress < 0.0) return 0.0;
-        return Math.min(1.0, progress);
+        long durationSeconds = countdown.getDurationSeconds();
+        if (durationSeconds <= 0L) return 1.0;
+        java.time.Instant target = countdown.getTargetInstant();
+        if (target == null) {
+            double progress = (double) remainingSeconds / (double) durationSeconds;
+            return Math.min(1.0, Math.max(0.0, progress));
+        }
+        // Use millisecond precision for smooth animation when called at sub-second frequency
+        long nowMillis = java.time.Instant.now().toEpochMilli();
+        long remainingMillis = Math.max(0L, target.toEpochMilli() - nowMillis);
+        double progress = (double) remainingMillis / ((double) durationSeconds * 1000.0);
+        return Math.min(1.0, Math.max(0.0, progress));
     }
 }

--- a/src/main/java/com/skyblockexp/ezcountdown/display/chat/ChatDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/chat/ChatDisplay.java
@@ -2,6 +2,7 @@ package com.skyblockexp.ezcountdown.display.chat;
 
 import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.display.DisplayHandler;
+import com.skyblockexp.ezcountdown.display.MessageBatch;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -14,6 +15,17 @@ public class ChatDisplay implements DisplayHandler {
             String perm = countdown.getVisibilityPermission();
             if (perm == null || perm.isBlank() || player.hasPermission(perm)) {
                 player.sendMessage(message);
+            }
+        }
+    }
+
+    @Override
+    public void displayBatched(Countdown countdown, String message, long remainingSeconds, MessageBatch batch) {
+        if (remainingSeconds <= 0L) return;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            String perm = countdown.getVisibilityPermission();
+            if (perm == null || perm.isBlank() || player.hasPermission(perm)) {
+                batch.add(player, countdown, message);
             }
         }
     }

--- a/src/main/java/com/skyblockexp/ezcountdown/display/scoreboard/ScoreboardDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/scoreboard/ScoreboardDisplay.java
@@ -162,8 +162,11 @@ public class ScoreboardDisplay implements StackableDisplay {
                     }
                 }
             } catch (NoClassDefFoundError | UnsupportedOperationException | IllegalArgumentException e) {
-                // fallback to chat if scoreboard ops fail
+                // fallback to chat if scoreboard ops fail — mirror the same guards used in the happy path
                 for (com.skyblockexp.ezcountdown.api.model.Countdown c : countdowns) {
+                    long rem = remaining.getOrDefault(c, 0L);
+                    if (rem <= 0L) continue; // skip countdown whose timer has reached zero
+                    if (!c.getDisplayTypes().contains(com.skyblockexp.ezcountdown.display.DisplayType.SCOREBOARD)) continue;
                     String perm = c.getVisibilityPermission();
                     if (perm == null || perm.isBlank() || player.hasPermission(perm)) {
                         String msg = messages.get(c);

--- a/src/main/java/com/skyblockexp/ezcountdown/display/title/TitleDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/title/TitleDisplay.java
@@ -2,6 +2,7 @@ package com.skyblockexp.ezcountdown.display.title;
 
 import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.display.DisplayHandler;
+import com.skyblockexp.ezcountdown.display.MessageBatch;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -21,6 +22,26 @@ public class TitleDisplay implements DisplayHandler {
                         player.sendActionBar(message);
                     } catch (NoSuchMethodError | NoClassDefFoundError ex) {
                         player.sendMessage(message);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void displayBatched(Countdown countdown, String message, long remainingSeconds, MessageBatch batch) {
+        if (remainingSeconds <= 0L) return;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            String perm = countdown.getVisibilityPermission();
+            if (perm == null || perm.isBlank() || player.hasPermission(perm)) {
+                try {
+                    player.sendTitle(message, "", 10, 40, 10);
+                } catch (NoSuchMethodError | NoClassDefFoundError err) {
+                    // Fallback to action bar if available, otherwise route through batch
+                    try {
+                        player.sendActionBar(message);
+                    } catch (NoSuchMethodError | NoClassDefFoundError ex) {
+                        batch.add(player, countdown, message);
                     }
                 }
             }

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
@@ -363,6 +363,8 @@ public final class CountdownManager {
                     // Otherwise stop the countdown and clear displays to avoid repeated end events.
                     countdown.setRunning(false);
                     displayManager.clearCountdown(countdown);
+                    // Persist the stopped state so a reload/restart does not re-fire the end event.
+                    try { save(); } catch (Exception ignored) {}
                 } finally {
                     flag.set(false);
                 }

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
@@ -271,14 +271,9 @@ public final class CountdownManager {
 
     private void startTask() {
         stopTask();
-        int intervalSeconds = 1;
-        try {
-            if (registry != null && registry.defaults() != null) {
-                intervalSeconds = Math.max(1, registry.defaults().updateIntervalSeconds());
-            }
-        } catch (Exception ignored) {}
-        long periodTicks = Math.max(1L, intervalSeconds) * 20L;
-        task = Bukkit.getScheduler().runTaskTimer(registry.plugin(), this::tick, periodTicks, periodTicks);
+        // Schedule at every game tick (1 tick = 50 ms) so bossbar and scoreboard can refresh
+        // smoothly. Text-based displays are still throttled per-countdown by updateIntervalSeconds.
+        task = Bukkit.getScheduler().runTaskTimer(registry.plugin(), this::tick, 1L, 1L);
     }
 
     private void stopTask() {
@@ -291,6 +286,7 @@ public final class CountdownManager {
     private void tick() {
         Instant now = Instant.now();
         java.util.List<Countdown> toUpdate = new java.util.ArrayList<>();
+        java.util.List<Countdown> allRunning = new java.util.ArrayList<>();
         java.util.Map<Countdown, String> messages = new java.util.HashMap<>();
         java.util.Map<Countdown, Long> remainingMap = new java.util.HashMap<>();
 
@@ -298,6 +294,7 @@ public final class CountdownManager {
             if (!countdown.isRunning()) {
                 continue;
             }
+            allRunning.add(countdown);
             Instant target = countdown.getTargetInstant();
             if (target == null) {
                 CountdownTypeHandler handler = registry.getHandler(countdown.getType());
@@ -321,7 +318,9 @@ public final class CountdownManager {
 
             long remaining = Math.max(0L, target.getEpochSecond() - now.getEpochSecond());
             Instant last = lastUpdate.getOrDefault(countdown.getName(), Instant.EPOCH);
-            if (now.isAfter(last.plusSeconds(countdown.getUpdateIntervalSeconds()))) {
+            // Use !isBefore (>=) rather than isAfter (>) so a tick that fires at exactly
+            // last + interval is not skipped due to strict comparison.
+            if (!now.isBefore(last.plusSeconds(countdown.getUpdateIntervalSeconds()))) {
                 lastUpdate.put(countdown.getName(), now);
                 String message = buildMessage(countdown, remaining);
                 toUpdate.add(countdown);
@@ -363,6 +362,14 @@ public final class CountdownManager {
                     // Otherwise stop the countdown and clear displays to avoid repeated end events.
                     countdown.setRunning(false);
                     displayManager.clearCountdown(countdown);
+                    // Guarantee the ended countdown is passed to displayAll with rem=0 so that
+                    // batch display handlers (ScoreboardDisplay batch sidebar, BossBarDisplay) also
+                    // clean up, even when the per-countdown update-interval was not due this tick.
+                    if (!messages.containsKey(countdown)) {
+                        toUpdate.add(countdown);
+                        messages.put(countdown, buildMessage(countdown, 0L));
+                    }
+                    remainingMap.put(countdown, 0L);
                     // Persist the stopped state so a reload/restart does not re-fire the end event.
                     try { save(); } catch (Exception ignored) {}
                 } finally {
@@ -370,12 +377,18 @@ public final class CountdownManager {
                 }
             }
         }
-        // Dispatch batch updates to display manager so stackable handlers can render multiple countdowns together
+        // Dispatch batch updates to display manager so stackable handlers (BossBar, Scoreboard)
+        // can render and clean up together. Ended countdowns are included at remaining=0 so
+        // StackableDisplay implementations receive the signal to remove their visuals (bossbar
+        // removeAll, scoreboard batch objective removal). Non-stackable handlers (Chat, ActionBar,
+        // Title) already guard against remainingSeconds<=0 and will not send extra messages.
         if (!toUpdate.isEmpty()) {
             try {
                 displayManager.displayAll(toUpdate, messages, remainingMap);
             } catch (Exception ignored) {}
         }
+        // Fast-refresh: update bossbar (smooth progress) and scoreboard every configured tick interval
+        displayManager.onTick(allRunning);
     }
 
     private String buildMessage(Countdown countdown, long remaining) {

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
@@ -23,8 +23,15 @@ import org.bukkit.entity.Player;
 public final class DisplayManager {
     private final Map<DisplayType, DisplayHandler> handlers = new EnumMap<>(DisplayType.class);
     private Validator.ValidationResult bossbarValidation;
+    /** Cached last-known display message per countdown name; used by the fast-refresh path. */
+    private final java.util.Map<String, String> lastMessageCache = new java.util.concurrent.ConcurrentHashMap<>();
+    private int bossbarRefreshTicks = 1;
+    private int scoreboardRefreshTicks = 1;
+    private long tickCount = 0;
 
     public DisplayManager(com.skyblockexp.ezcountdown.config.ConfigService configService) {
+        this.bossbarRefreshTicks = configService.loadBossbarRefreshTicks();
+        this.scoreboardRefreshTicks = configService.loadScoreboardRefreshTicks();
         configureHandlers(configService);
     }
 
@@ -88,6 +95,10 @@ public final class DisplayManager {
         for (DisplayHandler h : handlers.values()) {
             try { h.clearAll(); } catch (Exception ignored) {}
         }
+        lastMessageCache.clear();
+        tickCount = 0;
+        bossbarRefreshTicks = configService.loadBossbarRefreshTicks();
+        scoreboardRefreshTicks = configService.loadScoreboardRefreshTicks();
         configureHandlers(configService);
     }
 
@@ -110,7 +121,55 @@ public final class DisplayManager {
      * {@link com.skyblockexp.ezcountdown.display.StackableDisplay} will receive a
      * single bulk call; other handlers will be invoked per-countdown.
      */
+    /**
+     * Called every game tick (by default 1-tick scheduler) to fast-refresh bossbar progress
+     * and scoreboard visuals using cached messages, without triggering chat/actionbar/title spam.
+     */
+    public void onTick(java.util.Collection<Countdown> allRunning) {
+        tickCount++;
+        boolean doBossbar = (tickCount % bossbarRefreshTicks == 0) && handlers.containsKey(DisplayType.BOSS_BAR);
+        boolean doScoreboard = (tickCount % scoreboardRefreshTicks == 0) && handlers.containsKey(DisplayType.SCOREBOARD);
+        if (!doBossbar && !doScoreboard) return;
+
+        java.time.Instant now = java.time.Instant.now();
+        java.util.List<Countdown> bossbarList = new java.util.ArrayList<>();
+        java.util.List<Countdown> scoreboardList = new java.util.ArrayList<>();
+        java.util.Map<Countdown, String> msgMap = new java.util.HashMap<>();
+        java.util.Map<Countdown, Long> remMap = new java.util.HashMap<>();
+
+        for (Countdown c : allRunning) {
+            if (!c.isRunning() || c.getTargetInstant() == null) continue;
+            boolean hasBossbar = doBossbar && c.getDisplayTypes().contains(DisplayType.BOSS_BAR);
+            boolean hasScoreboard = doScoreboard && c.getDisplayTypes().contains(DisplayType.SCOREBOARD);
+            if (!hasBossbar && !hasScoreboard) continue;
+
+            long rem = Math.max(0L, c.getTargetInstant().getEpochSecond() - now.getEpochSecond());
+            msgMap.put(c, lastMessageCache.getOrDefault(c.getName(), ""));
+            remMap.put(c, rem);
+            if (hasBossbar) bossbarList.add(c);
+            if (hasScoreboard) scoreboardList.add(c);
+        }
+
+        if (doBossbar && !bossbarList.isEmpty()) {
+            DisplayHandler bh = handlers.get(DisplayType.BOSS_BAR);
+            if (bh instanceof com.skyblockexp.ezcountdown.display.StackableDisplay sd) {
+                try { sd.displayMultiple(bossbarList, msgMap, remMap); } catch (Exception ignored) {}
+            }
+        }
+        if (doScoreboard && !scoreboardList.isEmpty()) {
+            DisplayHandler sh = handlers.get(DisplayType.SCOREBOARD);
+            if (sh instanceof com.skyblockexp.ezcountdown.display.StackableDisplay sd) {
+                try { sd.displayMultiple(scoreboardList, msgMap, remMap); } catch (Exception ignored) {}
+            }
+        }
+    }
+
     public void displayAll(java.util.Collection<Countdown> countdowns, java.util.Map<Countdown, String> messages, java.util.Map<Countdown, Long> remaining) {
+        // Cache messages so the fast-refresh path (onTick) can use up-to-date text
+        for (Countdown c : countdowns) {
+            String msg = messages.get(c);
+            if (msg != null) lastMessageCache.put(c.getName(), msg);
+        }
         MessageBatch batch = new MessageBatch();
         for (DisplayType type : DisplayType.values()) {
             DisplayHandler h = handlers.get(type);
@@ -140,6 +199,7 @@ public final class DisplayManager {
     }
 
     public void clearCountdown(Countdown countdown) {
+        lastMessageCache.remove(countdown.getName());
         for (DisplayType type : countdown.getDisplayTypes()) {
             DisplayHandler h = handlers.get(type);
             if (h != null) h.clear(countdown);
@@ -147,6 +207,7 @@ public final class DisplayManager {
     }
 
     public void clearAll() {
+        lastMessageCache.clear();
         for (DisplayHandler h : handlers.values()) h.clearAll();
     }
 }

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
@@ -14,6 +14,7 @@ import com.skyblockexp.ezcountdown.display.scoreboard.ScoreboardValidator;
 import com.skyblockexp.ezcountdown.display.chat.ChatValidator;
 import com.skyblockexp.ezcountdown.display.title.TitleValidator;
 import com.skyblockexp.ezcountdown.display.title.TitleDisplay;
+import com.skyblockexp.ezcountdown.display.MessageBatch;
 import java.util.EnumMap;
 import java.util.Map;
 import org.bukkit.Bukkit;
@@ -94,12 +95,14 @@ public final class DisplayManager {
         // Do not show displays for countdowns that reached zero
         if (remainingSeconds <= 0L) return;
 
+        MessageBatch batch = new MessageBatch();
         for (DisplayType type : countdown.getDisplayTypes()) {
             DisplayHandler h = handlers.get(type);
             if (h != null) {
-                h.display(countdown, message, remainingSeconds);
+                h.displayBatched(countdown, message, remainingSeconds, batch);
             }
         }
+        batch.flush();
     }
 
     /**
@@ -108,6 +111,7 @@ public final class DisplayManager {
      * single bulk call; other handlers will be invoked per-countdown.
      */
     public void displayAll(java.util.Collection<Countdown> countdowns, java.util.Map<Countdown, String> messages, java.util.Map<Countdown, Long> remaining) {
+        MessageBatch batch = new MessageBatch();
         for (DisplayType type : DisplayType.values()) {
             DisplayHandler h = handlers.get(type);
             if (h == null) continue;
@@ -116,16 +120,17 @@ public final class DisplayManager {
                     sd.displayMultiple(countdowns, messages, remaining);
                 } catch (Exception ignored) {}
             } else {
-                // Fallback: call single display for each countdown that uses this type
+                // Route non-stackable handlers through the batch to deduplicate chat-channel messages
                 for (Countdown c : countdowns) {
                     if (c.getDisplayTypes().contains(type)) {
                         long rem = remaining.getOrDefault(c, 0L);
                         if (rem <= 0L) continue; // skip showing zero timers
-                        try { h.display(c, messages.get(c), rem); } catch (Exception ignored) {}
+                        try { h.displayBatched(c, messages.get(c), rem, batch); } catch (Exception ignored) {}
                     }
                 }
             }
         }
+        batch.flush();
     }
 
     public void broadcastMessage(String message) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,14 @@ permissions:
   info: "ezcountdown.use"
   reload: "ezcountdown.admin"
 
+display:
+  refresh:
+    # How often the bossbar progress bar and title are refreshed, in ticks (20 ticks = 1 second).
+    # Lower values produce smoother animation. Minimum is 1.
+    bossbar-ticks: 1
+    # How often the scoreboard sidebar is refreshed, in ticks. Minimum is 1.
+    scoreboard-ticks: 1
+
 display-overrides:
   # Set to true to force-enable a display type even if runtime checks fail.
   force-enable:

--- a/src/test/java/com/skyblockexp/ezcountdown/display/DisplayManagerStackableTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/display/DisplayManagerStackableTest.java
@@ -71,8 +71,8 @@ public class DisplayManagerStackableTest {
         // Stackable should be called once with both countdowns
         verify(stackable, times(1)).displayMultiple(eq(list), eq(messages), eq(remaining));
 
-        // Non-stackable should be called per-countdown (fallback path)
-        verify(nonStackable, times(2)).display(any(Countdown.class), anyString(), anyLong());
+        // Non-stackable should be called per-countdown via displayBatched
+        verify(nonStackable, times(2)).displayBatched(any(Countdown.class), anyString(), anyLong(), any(MessageBatch.class));
     }
 
     @Test
@@ -89,6 +89,6 @@ public class DisplayManagerStackableTest {
 
         displayManager.display(c, "hello", 3L);
 
-        verify(nonStackable, times(1)).display(eq(c), eq("hello"), eq(3L));
+        verify(nonStackable, times(1)).displayBatched(eq(c), eq("hello"), eq(3L), any(MessageBatch.class));
     }
 }

--- a/src/test/java/com/skyblockexp/ezcountdown/display/MessageBatchTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/display/MessageBatchTest.java
@@ -1,0 +1,104 @@
+package com.skyblockexp.ezcountdown.display;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import com.skyblockexp.ezcountdown.api.model.CountdownType;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MessageBatch}: deduplication and flush behaviour.
+ * Uses pure Mockito mocks — no MockBukkit requirement.
+ */
+public class MessageBatchTest {
+
+    private Player player;
+    private Countdown countdown;
+
+    @BeforeEach
+    public void setup() {
+        player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+
+        countdown = new Countdown("test", CountdownType.MANUAL,
+                EnumSet.of(DisplayType.CHAT), 1, null, "{formatted}", "s", "e",
+                Collections.emptyList(), ZoneId.systemDefault());
+    }
+
+    @Test
+    public void addSamePairTwice_flushSendsOneMessage() {
+        MessageBatch batch = new MessageBatch();
+        batch.add(player, countdown, "hello");
+        batch.add(player, countdown, "hello");
+
+        assertEquals(1, batch.size());
+        batch.flush();
+
+        verify(player, times(1)).sendMessage("hello");
+    }
+
+    @Test
+    public void addDifferentCountdowns_flushSendsBoth() {
+        Countdown other = new Countdown("other", CountdownType.MANUAL,
+                EnumSet.of(DisplayType.CHAT), 1, null, "{formatted}", "s", "e",
+                Collections.emptyList(), ZoneId.systemDefault());
+
+        MessageBatch batch = new MessageBatch();
+        batch.add(player, countdown, "msg-a");
+        batch.add(player, other, "msg-b");
+
+        assertEquals(2, batch.size());
+        batch.flush();
+
+        verify(player, times(1)).sendMessage("msg-a");
+        verify(player, times(1)).sendMessage("msg-b");
+    }
+
+    @Test
+    public void addSameCountdownDifferentPlayers_flushSendsBoth() {
+        Player second = mock(Player.class);
+        when(second.getUniqueId()).thenReturn(UUID.randomUUID());
+
+        MessageBatch batch = new MessageBatch();
+        batch.add(player, countdown, "hi");
+        batch.add(second, countdown, "hi");
+
+        assertEquals(2, batch.size());
+        batch.flush();
+
+        verify(player, times(1)).sendMessage("hi");
+        verify(second, times(1)).sendMessage("hi");
+    }
+
+    @Test
+    public void firstWriteWins_subsequentAddIgnored() {
+        MessageBatch batch = new MessageBatch();
+        batch.add(player, countdown, "first");
+        batch.add(player, countdown, "second");  // same player + countdown — ignored
+
+        batch.flush();
+
+        verify(player, times(1)).sendMessage("first");
+        verify(player, never()).sendMessage("second");
+    }
+
+    @Test
+    public void flushClearsBatch() {
+        MessageBatch batch = new MessageBatch();
+        batch.add(player, countdown, "msg");
+        batch.flush();
+        assertEquals(0, batch.size());
+
+        // Second flush on empty batch should not re-send
+        batch.flush();
+        verify(player, times(1)).sendMessage("msg");
+    }
+}

--- a/src/test/java/com/skyblockexp/ezcountdown/display/MultiDisplayDeduplicationTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/display/MultiDisplayDeduplicationTest.java
@@ -1,0 +1,75 @@
+package com.skyblockexp.ezcountdown.display;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import com.skyblockexp.ezcountdown.api.model.CountdownType;
+import com.skyblockexp.ezcountdown.manager.CountdownManager;
+import com.skyblockexp.ezcountdown.test.MockBukkitTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression test: a countdown with multiple display types that include CHAT should
+ * deliver exactly ONE chat message per player per tick — not one message per active
+ * display type.
+ */
+public class MultiDisplayDeduplicationTest extends MockBukkitTestBase {
+
+    @Test
+    public void chatAndActionBar_playerReceivesOnlyOneMessagePerTick() throws Exception {
+        var player = addPlayer("p1");
+
+        // Countdown with both CHAT and ACTION_BAR enabled; blank start/end messages
+        // to avoid fireStart() broadcasting a chat message that would skew the count.
+        Countdown c = new Countdown("multi", CountdownType.MANUAL,
+                EnumSet.of(DisplayType.CHAT, DisplayType.ACTION_BAR),
+                1, null, "{formatted}", "", "",
+                List.of(), ZoneId.systemDefault());
+        c.setRunning(true);
+        c.setDurationSeconds(10);
+        c.setTargetInstant(Instant.now().plusSeconds(5));
+
+        manager.createCountdown(c);
+
+        java.lang.reflect.Method tick = CountdownManager.class.getDeclaredMethod("tick");
+        tick.setAccessible(true);
+        tick.invoke(manager);
+
+        org.mockbukkit.mockbukkit.entity.PlayerMock pm = (org.mockbukkit.mockbukkit.entity.PlayerMock) player;
+
+        // Exactly one chat message expected (from CHAT display type via the batch)
+        assertNotNull(pm.nextComponentMessage(), "Expected exactly one chat message");
+        // No second message — deduplication is working
+        assertNull(pm.nextComponentMessage(), "Expected no second chat message (deduplication failure)");
+    }
+
+    @Test
+    public void chatTitleAndActionBar_playerReceivesOnlyOneMessagePerTick() throws Exception {
+        var player = addPlayer("p2");
+
+        Countdown c = new Countdown("multi2", CountdownType.MANUAL,
+                EnumSet.of(DisplayType.CHAT, DisplayType.ACTION_BAR, DisplayType.TITLE),
+                1, null, "{formatted}", "", "",
+                List.of(), ZoneId.systemDefault());
+        c.setRunning(true);
+        c.setDurationSeconds(10);
+        c.setTargetInstant(Instant.now().plusSeconds(5));
+
+        manager.createCountdown(c);
+
+        java.lang.reflect.Method tick = CountdownManager.class.getDeclaredMethod("tick");
+        tick.setAccessible(true);
+        tick.invoke(manager);
+
+        org.mockbukkit.mockbukkit.entity.PlayerMock pm = (org.mockbukkit.mockbukkit.entity.PlayerMock) player;
+
+        assertNotNull(pm.nextComponentMessage(), "Expected exactly one chat message");
+        assertNull(pm.nextComponentMessage(), "Expected no second chat message (deduplication failure)");
+    }
+}

--- a/src/test/java/com/skyblockexp/ezcountdown/manager/CountdownManagerBehaviorTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/manager/CountdownManagerBehaviorTest.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.util.EnumSet;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class CountdownManagerBehaviorTest {
@@ -116,6 +117,29 @@ public class CountdownManagerBehaviorTest {
         assertTrue(manager.getExecutedCount() >= 1);
         verify(displayManager, atLeastOnce()).broadcastMessage(nullable(String.class));
         verify(displayManager, atLeastOnce()).displayAll(anyCollection(), anyMap(), anyMap());
+    }
+
+    @Test
+    public void tickPersistsRunningFalseAfterNaturalEnd() throws Exception {
+        // Regression: if running=false is not saved after a natural end, the end message will
+        // re-fire on the next reload/restart because storage still has running=true.
+        Countdown c = new Countdown("persist-test", CountdownType.MANUAL,
+                EnumSet.noneOf(com.skyblockexp.ezcountdown.display.DisplayType.class),
+                1, null, "{formatted}", "", "",
+                java.util.List.of(), ZoneId.systemDefault());
+        c.setRunning(true);
+        c.setTargetInstant(java.time.Instant.now().minusSeconds(2));
+        manager.createCountdown(c);
+
+        java.lang.reflect.Method tick = CountdownManager.class.getDeclaredMethod("tick");
+        tick.setAccessible(true);
+        tick.invoke(manager);
+
+        // Countdown should be stopped in-memory
+        assertFalse(manager.getCountdown("persist-test").orElseThrow().isRunning());
+        // And the stopped state must have been saved to storage
+        verify(storage, atLeastOnce()).saveCountdowns(argThat(col ->
+                col.stream().anyMatch(cd -> cd.getName().equals("persist-test") && !cd.isRunning())));
     }
 }
 

--- a/src/test/java/com/skyblockexp/ezcountdown/manager/CountdownManagerBehaviorTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/manager/CountdownManagerBehaviorTest.java
@@ -115,8 +115,32 @@ public class CountdownManagerBehaviorTest {
 
         // after tick, executed count should have increased and displays should have been updated
         assertTrue(manager.getExecutedCount() >= 1);
+        // broadcastMessage fires for the start (via createCountdown) and the end — at least once each
         verify(displayManager, atLeastOnce()).broadcastMessage(nullable(String.class));
+        // displayAll receives the ended countdown at rem=0 so StackableDisplay handlers can clean up
         verify(displayManager, atLeastOnce()).displayAll(anyCollection(), anyMap(), anyMap());
+    }
+
+    @Test
+    public void endMessageSentExactlyOnceAcrossMultipleTicks() throws Exception {
+        // Configure the message manager stub to return the end message as-is so we can assert the exact value.
+        when(messageManager.formatWithPrefix(anyString(), anyMap())).thenAnswer(i -> i.getArgument(0));
+
+        Countdown c = new Countdown("once", CountdownType.MANUAL,
+                EnumSet.noneOf(com.skyblockexp.ezcountdown.display.DisplayType.class),
+                1, null, "{formatted}", "", "Ended!",
+                java.util.List.of(), ZoneId.systemDefault());
+        c.setRunning(true);
+        c.setTargetInstant(java.time.Instant.now().minusSeconds(5));
+        manager.createCountdown(c);
+
+        java.lang.reflect.Method tick = CountdownManager.class.getDeclaredMethod("tick");
+        tick.setAccessible(true);
+        // Run tick twice; end handling should fire on the first and be suppressed on the second
+        tick.invoke(manager);
+        tick.invoke(manager);
+
+        verify(displayManager, times(1)).broadcastMessage(eq("Ended!"));
     }
 
     @Test


### PR DESCRIPTION
**Feature changes**

- Fix issue in tick scheduling of the countdowns
- Added configurable refresh speed for the displays
```yaml
display:
  refresh:
    # How often the bossbar progress bar and title are refreshed, in ticks (20 ticks = 1 second).
    # Lower values produce smoother animation. Minimum is 1.
    bossbar-ticks: 1
    # How often the scoreboard sidebar is refreshed, in ticks. Minimum is 1.
    scoreboard-ticks: 1
```

**Code structure changes**

- Added `MessageBatch` structure to keep more clarity in 1 countdown with multiple displays being 1 "batch"
- Added `DisplayMessage` that represents 1 message for 1 display