### PR TITLE
feat: add DIALOG display type using Paper 1.21.7+ dialog API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezcountdown/command/subcommand/CreateSubcommand.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/command/subcommand/CreateSubcommand.java
@@ -42,6 +42,25 @@ public final class CreateSubcommand implements Subcommand {
             sender.sendMessage(messageManager.message("commands.create.usage"));
             return;
         }
+        // Pre-strip --display flags so they don't interfere with positional arg parsing
+        EnumSet<DisplayType> displayOverride = EnumSet.noneOf(DisplayType.class);
+        {
+            java.util.List<String> filtered = new java.util.ArrayList<>();
+            for (int i = 0; i < args.length; i++) {
+                if ("--display".equalsIgnoreCase(args[i]) && i + 1 < args.length) {
+                    String raw = args[++i];
+                    try {
+                        displayOverride.add(DisplayType.valueOf(raw.toUpperCase(Locale.ROOT)));
+                    } catch (IllegalArgumentException ex) {
+                        sender.sendMessage(messageManager.message("commands.create.invalid-display", Map.of("type", raw)));
+                        return;
+                    }
+                } else {
+                    filtered.add(args[i]);
+                }
+            }
+            args = filtered.toArray(new String[0]);
+        }
         String name = args[1];
         String typeToken = args[2];
         CountdownType type;
@@ -56,7 +75,9 @@ public final class CreateSubcommand implements Subcommand {
         }
 
         // build countdown with defaults using the builder so we can set new alignment options
-        EnumSet<DisplayType> displayTypes = EnumSet.copyOf(registry.defaults().displayTypes());
+        EnumSet<DisplayType> displayTypes = displayOverride.isEmpty()
+                ? EnumSet.copyOf(registry.defaults().displayTypes())
+                : displayOverride;
         com.skyblockexp.ezcountdown.api.model.CountdownBuilder builder = com.skyblockexp.ezcountdown.api.model.CountdownBuilder.builder(name)
             .type(type)
             .displayTypes(displayTypes)

--- a/src/main/java/com/skyblockexp/ezcountdown/display/DisplayType.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/DisplayType.java
@@ -5,5 +5,6 @@ public enum DisplayType {
     BOSS_BAR,
     CHAT,
     TITLE,
-    SCOREBOARD
+    SCOREBOARD,
+    DIALOG
 }

--- a/src/main/java/com/skyblockexp/ezcountdown/display/dialog/DialogDisplay.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/dialog/DialogDisplay.java
@@ -1,0 +1,168 @@
+package com.skyblockexp.ezcountdown.display.dialog;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import com.skyblockexp.ezcountdown.display.DisplayHandler;
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Displays countdown information as a Paper {@link Dialog}.
+ *
+ * <p><strong>No-flicker strategy:</strong> The handler tracks the last message
+ * that was sent to each player for a given countdown. When {@link #display} is
+ * called and the formatted message has not changed since the previous call, the
+ * existing open dialog is left on screen — no packet is sent and no visual
+ * disruption occurs. A dialog is only (re-)sent when the displayed text
+ * actually changes.
+ *
+ * <p>This class is intentionally scoped to Paper 1.21.7+ servers; the plugin's
+ * {@link DialogDisplayValidator} ensures it is never instantiated on runtimes
+ * that lack the API.
+ */
+@SuppressWarnings("UnstableApiUsage")
+public class DialogDisplay implements DisplayHandler {
+
+    /** Tracks the countdown name + last message text shown to each player. */
+    private record LastShown(String countdownName, String message) {}
+
+    /** Last shown state per player UUID. */
+    private final Map<UUID, LastShown> lastShown = new HashMap<>();
+
+    /**
+     * Reverse index: countdown name → set of player UUIDs who currently have
+     * a dialog from this countdown open. Used for efficient cleanup.
+     */
+    private final Map<String, Set<UUID>> sentByCountdown = new HashMap<>();
+
+    // -------------------------------------------------------------------------
+    // DisplayHandler
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void display(Countdown countdown, String message, long remainingSeconds) {
+        if (remainingSeconds <= 0L) {
+            clear(countdown);
+            return;
+        }
+
+        String cdName = countdown.getName();
+        String perm = countdown.getVisibilityPermission();
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (perm != null && !perm.isBlank() && !player.hasPermission(perm)) {
+                // Player lost permission — close any open dialog from this countdown
+                UUID uid = player.getUniqueId();
+                LastShown prev = lastShown.get(uid);
+                if (prev != null && prev.countdownName().equals(cdName)) {
+                    closeDialogSafely(player);
+                    lastShown.remove(uid);
+                    Set<UUID> viewers = sentByCountdown.get(cdName);
+                    if (viewers != null) viewers.remove(uid);
+                }
+                continue;
+            }
+
+            UUID uid = player.getUniqueId();
+            LastShown prev = lastShown.get(uid);
+
+            // Skip if this player is already showing the exact same text
+            if (prev != null && prev.countdownName().equals(cdName) && prev.message().equals(message)) {
+                continue;
+            }
+
+            showDialogToPlayer(player, countdown, message);
+            lastShown.put(uid, new LastShown(cdName, message));
+            sentByCountdown.computeIfAbsent(cdName, k -> new HashSet<>()).add(uid);
+        }
+    }
+
+    @Override
+    public void clear(Countdown countdown) {
+        String cdName = countdown.getName();
+        Set<UUID> viewers = sentByCountdown.remove(cdName);
+        if (viewers == null) return;
+
+        for (UUID uid : viewers) {
+            LastShown prev = lastShown.get(uid);
+            if (prev != null && prev.countdownName().equals(cdName)) {
+                Player player = Bukkit.getPlayer(uid);
+                if (player != null && player.isOnline()) {
+                    closeDialogSafely(player);
+                }
+                lastShown.remove(uid);
+            }
+        }
+    }
+
+    @Override
+    public void clearAll() {
+        for (Map.Entry<String, Set<UUID>> entry : sentByCountdown.entrySet()) {
+            for (UUID uid : entry.getValue()) {
+                Player player = Bukkit.getPlayer(uid);
+                if (player != null && player.isOnline()) {
+                    closeDialogSafely(player);
+                }
+            }
+        }
+        sentByCountdown.clear();
+        lastShown.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void showDialogToPlayer(Player player, Countdown countdown, String message) {
+        try {
+            Dialog dialog = Dialog.create(builder -> builder.empty()
+                    .base(DialogBase.builder(
+                                    Component.text(countdown.getName(), NamedTextColor.GOLD))
+                            .body(List.of(DialogBody.plainMessage(
+                                    Component.text(message))))
+                            .canCloseWithEscape(true)
+                            .build())
+                    .type(DialogType.notice(
+                            ActionButton.create(
+                                    Component.text("Close", NamedTextColor.GRAY),
+                                    Component.text("Dismiss this dialog"),
+                                    200,
+                                    null))));
+            player.showDialog(dialog);
+        } catch (Exception e) {
+            // Defensive: API may behave unexpectedly on edge-case server builds
+            Bukkit.getLogger().fine("EzCountdown: failed to show dialog to " + player.getName() + ": " + e.getMessage());
+        }
+    }
+
+    private void closeDialogSafely(Player player) {
+        try {
+            player.closeDialog();
+        } catch (Exception ignored) {}
+    }
+
+    /**
+     * Removes stale entries for players who have gone offline, preventing
+     * unbounded map growth on long-running servers.
+     */
+    public void pruneOfflinePlayers() {
+        lastShown.entrySet().removeIf(e -> Bukkit.getPlayer(e.getKey()) == null);
+        for (Set<UUID> viewers : sentByCountdown.values()) {
+            viewers.removeIf(uid -> Bukkit.getPlayer(uid) == null);
+        }
+    }
+}

--- a/src/main/java/com/skyblockexp/ezcountdown/display/dialog/DialogDisplayValidator.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/display/dialog/DialogDisplayValidator.java
@@ -1,0 +1,27 @@
+package com.skyblockexp.ezcountdown.display.dialog;
+
+import com.skyblockexp.ezcountdown.display.Validator;
+
+/**
+ * Validates whether the Paper Dialog API (introduced in Paper 1.21.7) is
+ * available on the current server runtime.
+ *
+ * <p>The check is performed entirely via reflection so that the plugin can
+ * still load on Paper builds that predate the dialog API — the display type
+ * will simply be skipped with a warning.
+ */
+public class DialogDisplayValidator extends Validator {
+
+    @Override
+    public ValidationResult validate() {
+        try {
+            Class.forName("io.papermc.paper.dialog.Dialog");
+            // Also check that Audience#showDialog exists (requires Adventure 4.22+)
+            Class.forName("net.kyori.adventure.dialog.DialogLike");
+            return ValidationResult.ok();
+        } catch (ClassNotFoundException e) {
+            return ValidationResult.fail(
+                    "Dialog display requires Paper 1.21.7+ with the Dialog API (io.papermc.paper.dialog.Dialog not found).");
+        }
+    }
+}

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/DisplayManager.java
@@ -14,6 +14,8 @@ import com.skyblockexp.ezcountdown.display.scoreboard.ScoreboardValidator;
 import com.skyblockexp.ezcountdown.display.chat.ChatValidator;
 import com.skyblockexp.ezcountdown.display.title.TitleValidator;
 import com.skyblockexp.ezcountdown.display.title.TitleDisplay;
+import com.skyblockexp.ezcountdown.display.dialog.DialogDisplay;
+import com.skyblockexp.ezcountdown.display.dialog.DialogDisplayValidator;
 import com.skyblockexp.ezcountdown.display.MessageBatch;
 import java.util.EnumMap;
 import java.util.Map;
@@ -87,6 +89,16 @@ public final class DisplayManager {
             if (!bossbarValidation.isValid()) Bukkit.getLogger().info("EzCountdown: boss bar force-enabled via config.");
         } else {
             Bukkit.getLogger().warning("EzCountdown: boss bar display disabled: " + bossbarValidation.getMessage());
+        }
+
+        // Dialog (Paper 1.21.7+)
+        Validator.ValidationResult dialogValidation = new DialogDisplayValidator().validate();
+        boolean dialogForce = overrides.getOrDefault(DisplayType.DIALOG, false);
+        if (dialogValidation.isValid() || dialogForce) {
+            handlers.put(DisplayType.DIALOG, new DialogDisplay());
+            if (!dialogValidation.isValid()) Bukkit.getLogger().info("EzCountdown: dialog display force-enabled via config.");
+        } else {
+            Bukkit.getLogger().warning("EzCountdown: dialog display disabled: " + dialogValidation.getMessage());
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ defaults:
   # - CHAT
   # - TITLE
   # - SCOREBOARD
+  # - DIALOG  (requires Paper 1.21.7+)
   display-types:
     - ACTION_BAR
   update-interval: 1

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,7 @@ defaults:
 
 commands:
   no-permission: "{prefix}<red>You do not have permission to use this command.</red>"
+  error: "{prefix}<red>An error occurred:</red> <white>{reason}</white>"
   usage:
     header: "{prefix}<white>Available commands:</white>"
     create: "<gray>/countdown create <name> <date|duration|manual|recurring></gray>"
@@ -29,6 +30,7 @@ commands:
     invalid-date: "{prefix}<red>Invalid date format. Use yyyy-MM-dd HH:mm.</red>"
     invalid-recurring: "{prefix}<red>Invalid recurring date. Use <month> <day> <HH:mm>.</red>"
     invalid-duration: "{prefix}<red>Invalid duration:</red> <white>{reason}</white>"
+    invalid-display: "{prefix}<red>Unknown display type:</red> <white>{type}</white><red>. Valid types: ACTION_BAR, BOSS_BAR, CHAT, TITLE, SCOREBOARD, DIALOG</red>"
     exists: "{prefix}<red>A countdown named</red> <white>{name}</white> <red>already exists.</red>"
     success: "{prefix}<green>Created countdown</green> <white>{name}</white><green>.</green>"
   start:


### PR DESCRIPTION
- Add DialogDisplay handler with no-flicker logic (only sends packet when formatted message text actually changes per player)
- Add DialogDisplayValidator for graceful runtime detection of the experimental Paper dialog API (requires Paper 1.21.7+)
- Register DIALOG in DisplayManager.configureHandlers() alongside existing display types
- Add --display flag to /countdown create command e.g. /countdown create test duration 10s --display DIALOG
- Add commands.error message key to messages.yml (fixes blank chat line when command handler throws an uncaught exception)
- Add DIALOG to config.yml display-types comment
- Bump version to 1.3.0

<img width="427" height="461" alt="image" src="https://github.com/user-attachments/assets/2341d7d2-0f1a-4d3e-9351-76412b289eb3" />
