### PR TITLE
fix: persist targetInstant for duration countdowns across restarts

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -35,7 +35,7 @@ Follow these steps to add and use the EzCountdown API from your plugin.
 <dependency>
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.0.0</version>
+    <version>1.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezcountdown/type/DurationHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/type/DurationHandler.java
@@ -55,8 +55,13 @@ public class DurationHandler implements CountdownTypeHandler {
         String durationValue = section.getString("duration", "0s");
         long seconds = parseDurationLegacy(durationValue);
         countdown.setDurationSeconds(seconds);
-        if (countdown.isRunning() && countdown.getTargetInstant() == null) {
-            countdown.setTargetInstant(Instant.now().plusSeconds(countdown.getDurationSeconds()));
+        if (countdown.isRunning()) {
+            long savedTarget = section.getLong("target_epoch", -1L);
+            if (savedTarget >= 0) {
+                countdown.setTargetInstant(Instant.ofEpochSecond(savedTarget));
+            } else {
+                countdown.setTargetInstant(Instant.now().plusSeconds(countdown.getDurationSeconds()));
+            }
         }
         return countdown;
     }
@@ -79,6 +84,9 @@ public class DurationHandler implements CountdownTypeHandler {
     @Override
     public void serialize(Countdown countdown, ConfigurationSection section) {
         section.set("duration", countdown.getDurationSeconds() + "s");
+        if (countdown.getTargetInstant() != null) {
+            section.set("target_epoch", countdown.getTargetInstant().getEpochSecond());
+        }
     }
 
     @Override

--- a/src/test/java/com/skyblockexp/ezcountdown/storage/YamlCountdownStorageRoundtripTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/storage/YamlCountdownStorageRoundtripTest.java
@@ -4,13 +4,17 @@ import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.display.DisplayType;
 import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
+import com.skyblockexp.ezcountdown.type.DurationHandler;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -44,5 +48,67 @@ public class YamlCountdownStorageRoundtripTest {
         assertTrue(foundDuration);
         assertTrue(foundFixed);
         tmp.delete();
+    }
+
+    /**
+     * Regression test for: duration countdown resets to full duration on server restart.
+     *
+     * Scenario: a duration countdown is active and displayed via scoreboard/placeholder.
+     * After saving and reloading (simulating a server restart) the countdown should resume
+     * from its remaining time, NOT reset to the full configured duration.
+     *
+     * This test exposes the bug: {@code DurationHandler.serialize()} never persists
+     * {@code targetInstant}, so on reload {@code parse()} recalculates it from
+     * {@code Instant.now() + fullDuration} instead of restoring the original target.
+     */
+    @Test
+    public void durationCountdownPreservesTargetInstantAcrossRestart() throws Exception {
+        File tmp = File.createTempFile("countdowns-restart-bug", ".yml");
+        tmp.deleteOnExit();
+
+        CountdownDefaults defaults = new CountdownDefaults(
+                EnumSet.noneOf(DisplayType.class), 1, null,
+                "{formatted}", "start", "end", true, ZoneId.of("UTC"));
+
+        YamlCountdownStorage storage = new YamlCountdownStorage(
+                defaults, tmp, java.util.logging.Logger.getLogger("restart-bug-save"));
+        storage.setHandlerRegistry(Map.of(CountdownType.DURATION, new DurationHandler()));
+
+        long fullDurationSeconds = 1000L;
+        // Simulate the countdown already being halfway through: 500s remaining out of 1000s.
+        long remainingSeconds = 500L;
+
+        Countdown original = new Countdown("scoreboard-event", CountdownType.DURATION,
+                EnumSet.of(DisplayType.SCOREBOARD), 1, null, "{time}", "start", "end",
+                List.of(), ZoneId.of("UTC"));
+        original.setDurationSeconds(fullDurationSeconds);
+        original.setRunning(true);
+        Instant originalTarget = Instant.now().plusSeconds(remainingSeconds);
+        original.setTargetInstant(originalTarget);
+
+        // "Server shuts down" — save state to disk.
+        storage.saveCountdowns(List.of(original));
+
+        // "Server restarts" — load state from disk with a fresh storage instance.
+        YamlCountdownStorage reloader = new YamlCountdownStorage(
+                defaults, tmp, java.util.logging.Logger.getLogger("restart-bug-load"));
+        reloader.setHandlerRegistry(Map.of(CountdownType.DURATION, new DurationHandler()));
+        Collection<Countdown> loaded = reloader.loadCountdowns();
+
+        Countdown reloaded = loaded.stream()
+                .filter(c -> c.getName().equals("scoreboard-event"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Countdown 'scoreboard-event' not found after reload"));
+
+        assertNotNull(reloaded.getTargetInstant(),
+                "targetInstant must be non-null after restart — countdown should still be running");
+
+        // Remaining time must be close to the original 500s, not reset to the full 1000s.
+        long reloadedRemainingSeconds =
+                Duration.between(Instant.now(), reloaded.getTargetInstant()).toSeconds();
+
+        assertTrue(reloadedRemainingSeconds <= remainingSeconds + 5,
+                "BUG ACTIVE — countdown reset to full duration on restart. " +
+                "Expected remaining ≈ " + remainingSeconds + "s but got " + reloadedRemainingSeconds + "s.");
     }
 }


### PR DESCRIPTION
Duration countdowns were resetting to their full configured duration after a server restart because DurationHandler.serialize() never saved the current targetInstant. On reload, parse() recalculated it as Instant.now() + fullDuration, discarding elapsed time.

Fix: serialize() now writes target_epoch (Unix epoch second) alongside duration. parse() restores targetInstant from target_epoch when present, falling back to now + fullDuration only for legacy save files that lack the key.

Regression test added: durationCountdownPreservesTargetInstantAcrossRestart in YamlCountdownStorageRoundtripTest.