### PR TITLE
fix: bossbar style and color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-16
+
+### Fixed
+
+- **Bossbar color/style ignored** - `display.bossbar.color` and `display.bossbar.style` in `countdowns.yml` had no effect; the boss bar always rendered in the default blue/solid style. All four countdown-type handlers (`DurationHandler`, `FixedDateHandler`, `RecurringHandler`, `ManualHandler`) now read these fields from config and pass them to the `Countdown` constructor.
+
 ## [1.4.0] - 2026-05-11
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezcountdown/type/DurationHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/type/DurationHandler.java
@@ -5,6 +5,8 @@ import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.display.DisplayType;
 import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
 import com.skyblockexp.ezcountdown.util.DurationParser;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.time.Instant;
@@ -50,7 +52,10 @@ public class DurationHandler implements CountdownTypeHandler {
         com.skyblockexp.ezcountdown.api.model.MissedRunPolicy missedPolicy;
         try { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.valueOf(missedRunRaw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.SKIP; }
 
-        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy);
+        BarColor bossColor = parseBossBarColor(section.getString("display.bossbar.color", "BLUE"));
+        BarStyle bossStyle = parseBossBarStyle(section.getString("display.bossbar.style", "SOLID"));
+
+        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy, bossColor, bossStyle);
         countdown.setRunning(section.getBoolean("running", defaults.startOnCreate()));
         String durationValue = section.getString("duration", "0s");
         long seconds = parseDurationLegacy(durationValue);
@@ -64,6 +69,14 @@ public class DurationHandler implements CountdownTypeHandler {
             }
         }
         return countdown;
+    }
+
+    private static BarColor parseBossBarColor(String raw) {
+        try { return BarColor.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarColor.BLUE; }
+    }
+
+    private static BarStyle parseBossBarStyle(String raw) {
+        try { return BarStyle.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarStyle.SOLID; }
     }
 
     private long parseDurationLegacy(String value) {

--- a/src/main/java/com/skyblockexp/ezcountdown/type/FixedDateHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/type/FixedDateHandler.java
@@ -4,6 +4,8 @@ import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.display.DisplayType;
 import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.time.Instant;
@@ -54,7 +56,10 @@ public class FixedDateHandler implements CountdownTypeHandler {
         com.skyblockexp.ezcountdown.api.model.MissedRunPolicy missedPolicy;
         try { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.valueOf(missedRunRaw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.SKIP; }
 
-        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy);
+        BarColor bossColor = parseBossBarColor(section.getString("display.bossbar.color", "BLUE"));
+        BarStyle bossStyle = parseBossBarStyle(section.getString("display.bossbar.style", "SOLID"));
+
+        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy, bossColor, bossStyle);
         countdown.setRunning(section.getBoolean("running", defaults.startOnCreate()));
         String target = section.getString("target");
         if (target == null) throw new IllegalArgumentException("Missing target date for fixed date countdown.");
@@ -62,6 +67,14 @@ public class FixedDateHandler implements CountdownTypeHandler {
         LocalDateTime dt = LocalDateTime.parse(target, DATE_TIME_FORMAT);
         countdown.setTargetInstant(dt.atZone(zoneId).toInstant());
         return countdown;
+    }
+
+    private static BarColor parseBossBarColor(String raw) {
+        try { return BarColor.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarColor.BLUE; }
+    }
+
+    private static BarStyle parseBossBarStyle(String raw) {
+        try { return BarStyle.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarStyle.SOLID; }
     }
 
     @Override

--- a/src/main/java/com/skyblockexp/ezcountdown/type/ManualHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/type/ManualHandler.java
@@ -5,6 +5,8 @@ import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.display.DisplayType;
 import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
 import com.skyblockexp.ezcountdown.util.DurationParser;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.time.Instant;
@@ -50,7 +52,10 @@ public class ManualHandler implements CountdownTypeHandler {
         com.skyblockexp.ezcountdown.api.model.MissedRunPolicy missedPolicy;
         try { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.valueOf(missedRunRaw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.SKIP; }
 
-        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy);
+        BarColor bossColor = parseBossBarColor(section.getString("display.bossbar.color", "BLUE"));
+        BarStyle bossStyle = parseBossBarStyle(section.getString("display.bossbar.style", "SOLID"));
+
+        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy, bossColor, bossStyle);
         countdown.setRunning(section.getBoolean("running", false));
         String durationValue = section.getString("duration", "0s");
         long seconds = parseDurationLegacy(durationValue);
@@ -59,6 +64,14 @@ public class ManualHandler implements CountdownTypeHandler {
             countdown.setTargetInstant(Instant.now().plusSeconds(countdown.getDurationSeconds()));
         }
         return countdown;
+    }
+
+    private static BarColor parseBossBarColor(String raw) {
+        try { return BarColor.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarColor.BLUE; }
+    }
+
+    private static BarStyle parseBossBarStyle(String raw) {
+        try { return BarStyle.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarStyle.SOLID; }
     }
 
     private long parseDurationLegacy(String value) {

--- a/src/main/java/com/skyblockexp/ezcountdown/type/RecurringHandler.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/type/RecurringHandler.java
@@ -4,6 +4,8 @@ import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.display.DisplayType;
 import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.time.Instant;
@@ -55,7 +57,10 @@ public class RecurringHandler implements CountdownTypeHandler {
             missedPolicy = com.skyblockexp.ezcountdown.api.model.MissedRunPolicy.SKIP;
         }
 
-        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy);
+        BarColor bossColor = parseBossBarColor(section.getString("display.bossbar.color", "BLUE"));
+        BarStyle bossStyle = parseBossBarStyle(section.getString("display.bossbar.style", "SOLID"));
+
+        Countdown countdown = new Countdown(name, getType(), displayTypes, updateInterval, visibility, format, start, end, endCommands, zone, autoRestart, startCountdown, restartDelay, alignToClock, alignInterval, missedPolicy, bossColor, bossStyle);
         countdown.setRunning(section.getBoolean("running", true));
         countdown.setRecurringMonth(section.getInt("recurring.month", 1));
         countdown.setRecurringDay(section.getInt("recurring.day", 1));
@@ -63,6 +68,14 @@ public class RecurringHandler implements CountdownTypeHandler {
         countdown.setRecurringTime(LocalTime.parse(timeValue));
         countdown.setTargetInstant(countdown.resolveNextRecurringTarget(Instant.now()));
         return countdown;
+    }
+
+    private static BarColor parseBossBarColor(String raw) {
+        try { return BarColor.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarColor.BLUE; }
+    }
+
+    private static BarStyle parseBossBarStyle(String raw) {
+        try { return BarStyle.valueOf(raw.toUpperCase(Locale.ROOT)); } catch (IllegalArgumentException ex) { return BarStyle.SOLID; }
     }
 
     @Override

--- a/src/test/java/com/skyblockexp/ezcountdown/type/BossBarColorConfigTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/type/BossBarColorConfigTest.java
@@ -1,0 +1,159 @@
+package com.skyblockexp.ezcountdown.type;
+
+import com.skyblockexp.ezcountdown.api.model.Countdown;
+import com.skyblockexp.ezcountdown.display.DisplayType;
+import com.skyblockexp.ezcountdown.manager.CountdownDefaults;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.time.ZoneId;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for https://github.com/... — bossbar color configured in
+ * countdowns.yml was always ignored; the bar stayed blue regardless of the
+ * value set under display.bossbar.color.
+ *
+ * Each test mirrors the user-reported config:
+ *   display:
+ *     bossbar:
+ *       color: WHITE
+ *       style: NOTCHED_6
+ *
+ * Before the fix every handler returned BarColor.BLUE / BarStyle.SOLID because
+ * the shorter Countdown constructor was used which hard-codes those defaults.
+ */
+public class BossBarColorConfigTest {
+
+    private static final CountdownDefaults DEFAULTS = new CountdownDefaults(
+            EnumSet.noneOf(DisplayType.class), 1, null, "", "", "", false, ZoneId.of("UTC"));
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static org.bukkit.configuration.ConfigurationSection sectionFrom(String yaml) {
+        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(new StringReader(yaml));
+        // The YAML contains a single top-level key "countdown" that holds the section.
+        return cfg.getConfigurationSection("countdown");
+    }
+
+    // -------------------------------------------------------------------------
+    // DURATION handler
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void durationHandler_parse_respectsBossBarColor() {
+        String yaml =
+                "countdown:\n" +
+                "  type: DURATION\n" +
+                "  duration: 3600s\n" +
+                "  running: false\n" +
+                "  display:\n" +
+                "    types: [BOSS_BAR]\n" +
+                "    bossbar:\n" +
+                "      color: WHITE\n" +
+                "      style: SEGMENTED_6\n";
+
+        Countdown cd = new DurationHandler().parse("SoulBinder", sectionFrom(yaml), DEFAULTS);
+
+        assertEquals(BarColor.WHITE, cd.getBossBarColor(),
+                "DurationHandler.parse() must read display.bossbar.color from config");
+        assertEquals(BarStyle.SEGMENTED_6, cd.getBossBarStyle(),
+                "DurationHandler.parse() must read display.bossbar.style from config");
+    }
+
+    @Test
+    public void durationHandler_parse_defaultsToBlueWhenKeyAbsent() {
+        String yaml =
+                "countdown:\n" +
+                "  type: DURATION\n" +
+                "  duration: 60s\n" +
+                "  running: false\n" +
+                "  display:\n" +
+                "    types: [BOSS_BAR]\n";
+
+        Countdown cd = new DurationHandler().parse("noBossBarKey", sectionFrom(yaml), DEFAULTS);
+
+        assertEquals(BarColor.BLUE, cd.getBossBarColor(),
+                "DurationHandler.parse() must fall back to BLUE when color key is absent");
+        assertEquals(BarStyle.SOLID, cd.getBossBarStyle(),
+                "DurationHandler.parse() must fall back to SOLID when style key is absent");
+    }
+
+    // -------------------------------------------------------------------------
+    // FIXED_DATE handler
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void fixedDateHandler_parse_respectsBossBarColor() {
+        String yaml =
+                "countdown:\n" +
+                "  type: FIXED_DATE\n" +
+                "  target: \"2030-01-01 00:00\"\n" +
+                "  display:\n" +
+                "    types: [BOSS_BAR]\n" +
+                "    bossbar:\n" +
+                "      color: RED\n" +
+                "      style: SEGMENTED_12\n";
+
+        Countdown cd = new FixedDateHandler().parse("event", sectionFrom(yaml), DEFAULTS);
+
+        assertEquals(BarColor.RED, cd.getBossBarColor(),
+                "FixedDateHandler.parse() must read display.bossbar.color from config");
+        assertEquals(BarStyle.SEGMENTED_12, cd.getBossBarStyle(),
+                "FixedDateHandler.parse() must read display.bossbar.style from config");
+    }
+
+    // -------------------------------------------------------------------------
+    // RECURRING handler
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void recurringHandler_parse_respectsBossBarColor() {
+        String yaml =
+                "countdown:\n" +
+                "  type: RECURRING\n" +
+                "  recurring:\n" +
+                "    month: 6\n" +
+                "    day: 15\n" +
+                "    time: \"12:00\"\n" +
+                "  display:\n" +
+                "    types: [BOSS_BAR]\n" +
+                "    bossbar:\n" +
+                "      color: GREEN\n" +
+                "      style: SOLID\n";
+
+        Countdown cd = new RecurringHandler().parse("weekly", sectionFrom(yaml), DEFAULTS);
+
+        assertEquals(BarColor.GREEN, cd.getBossBarColor(),
+                "RecurringHandler.parse() must read display.bossbar.color from config");
+    }
+
+    // -------------------------------------------------------------------------
+    // MANUAL handler
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void manualHandler_parse_respectsBossBarColor() {
+        String yaml =
+                "countdown:\n" +
+                "  type: MANUAL\n" +
+                "  duration: 120s\n" +
+                "  display:\n" +
+                "    types: [BOSS_BAR]\n" +
+                "    bossbar:\n" +
+                "      color: PURPLE\n" +
+                "      style: SOLID\n";
+
+        Countdown cd = new ManualHandler().parse("manual", sectionFrom(yaml), DEFAULTS);
+
+        assertEquals(BarColor.PURPLE, cd.getBossBarColor(),
+                "ManualHandler.parse() must read display.bossbar.color from config");
+    }
+}


### PR DESCRIPTION
**Bossbar color/style ignored** - `display.bossbar.color` and `display.bossbar.style` in `countdowns.yml` had no effect; the boss bar always rendered in the default blue/solid style. All four countdown-type handlers (`DurationHandler`, `FixedDateHandler`, `RecurringHandler`, `ManualHandler`) now read these fields from config and pass them to the `Countdown` constructor.