### PR TITLE
feat: added configurable time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-16
+
+### Added
+
+- **Configurable time format** — new `display.time-format` section in `config.yml`.
+  - `pattern` (default `"{days}d {hours}h {minutes}m {seconds}s"`) — customize the token layout used for the `{formatted}` placeholder and `%ezcountdown_<name>_formatted%` PAPI expansion.
+  - `hide-leading-zeros` (default `true`) — when enabled, leading space-delimited segments whose unit value is zero are suppressed. For example, `0d 0h 5m 3s` is displayed as `5m 3s`.
+  - Applies to countdown display messages, discord webhook `{time_left}`, PlaceholderAPI, and the GUI preview action.
+  - Hot-reloads with `/countdown reload`.
+
 ## [1.4.1] - 2026-05-16
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,26 @@ countdowns:
       end: arena
 ```
 
+**Time Format**
+
+The `{formatted}` placeholder (and `%ezcountdown_<name>_formatted%`) is driven by two settings under `display.time-format` in `config.yml`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `display.time-format.pattern` | string | `"{days}d {hours}h {minutes}m {seconds}s"` | Token layout. Supported tokens: `{days}`, `{hours}`, `{minutes}`, `{seconds}`. |
+| `display.time-format.hide-leading-zeros` | boolean | `true` | When `true`, leading space-delimited segments whose unit value is `0` are omitted. At least the last segment is always shown. |
+
+Examples with `hide-leading-zeros: true`:
+
+| Remaining | Output |
+|-----------|--------|
+| 2d 5h 3m 7s | `2d 5h 3m 7s` |
+| 0d 2h 5m 3s | `2h 5m 3s` |
+| 0d 0h 0m 45s | `45s` |
+| 0d 0h 0m 0s | `0s` |
+
+These settings are reloaded with `/countdown reload`.
+
 **Boss Bar Customization**
 
 - `display.bossbar.color`: (optional) A `BarColor` name used for the countdown's boss bar. Valid values include `BLUE`, `RED`, `GREEN`, `YELLOW`, `PINK`, `PURPLE`, `WHITE` (matching Bukkit's `BarColor` enum). Default: `BLUE`.

--- a/docs/feature/placeholders.md
+++ b/docs/feature/placeholders.md
@@ -14,7 +14,7 @@ Available placeholders (replace `<name>` with your countdown's name):
 - `%ezcountdown_<name>_hours%`
 - `%ezcountdown_<name>_minutes%`
 - `%ezcountdown_<name>_seconds%`
- - `%ezcountdown_<name>_formatted%` - combined, human-friendly format (e.g. "1d 2h 3m 4s").
+- `%ezcountdown_<name>_formatted%` - combined, human-friendly format driven by `display.time-format` in `config.yml`. With the default `hide-leading-zeros: true`, leading zero units are omitted (e.g. `5m 3s` instead of `0d 0h 5m 3s`).
 
 Usage examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/main/java/com/skyblockexp/ezcountdown/bootstrap/PluginBootstrap.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/bootstrap/PluginBootstrap.java
@@ -85,6 +85,7 @@ public final class PluginBootstrap {
         CountdownManager countdownManager = new CountdownManager(registry, discordWebhookConfig, storage, displayManager, messageManager, locationManager);
         // register into registry
         registry.setCountdownManager(countdownManager);
+        countdownManager.setTimeFormatConfig(configService.loadTimeFormatConfig());
         countdownManager.load();
         int loadedCount = countdownManager.getCountdownCount();
         long runningCount = countdownManager.getCountdowns().stream().filter(c -> c.isRunning()).count();
@@ -146,6 +147,12 @@ public final class PluginBootstrap {
                     displayManager.reload(configService);
                 } catch (Exception ex) {
                     plugin.getLogger().log(java.util.logging.Level.WARNING, "Failed to reload display manager", ex);
+                }
+
+                try {
+                    registry.countdowns().setTimeFormatConfig(configService.loadTimeFormatConfig());
+                } catch (Exception ex) {
+                    plugin.getLogger().log(java.util.logging.Level.WARNING, "Failed to reload time format config", ex);
                 }
 
                 try {

--- a/src/main/java/com/skyblockexp/ezcountdown/config/ConfigService.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/config/ConfigService.java
@@ -7,6 +7,7 @@ import com.skyblockexp.ezcountdown.command.CountdownPermissions;
 import com.skyblockexp.ezcountdown.command.LocationPermissions;
 import com.skyblockexp.ezcountdown.config.DiscordWebhookConfig;
 import com.skyblockexp.ezcountdown.display.DisplayType;
+import com.skyblockexp.ezcountdown.util.TimeFormat;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.File;
@@ -102,6 +103,14 @@ public final class ConfigService {
     public int loadScoreboardRefreshTicks() {
         int v = plugin.getConfig().getInt("display.refresh.scoreboard-ticks", 1);
         return Math.max(1, v);
+    }
+
+    public TimeFormat.FormatConfig loadTimeFormatConfig() {
+        FileConfiguration config = plugin.getConfig();
+        String pattern = config.getString("display.time-format.pattern", TimeFormat.DEFAULT_PATTERN);
+        if (pattern == null || pattern.isBlank()) pattern = TimeFormat.DEFAULT_PATTERN;
+        boolean hideLeadingZeros = config.getBoolean("display.time-format.hide-leading-zeros", false);
+        return new TimeFormat.FormatConfig(pattern, hideLeadingZeros);
     }
 
     private void ensureResource(String name) {

--- a/src/main/java/com/skyblockexp/ezcountdown/integration/placeholder/EzCountdownPlaceholderExpansion.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/integration/placeholder/EzCountdownPlaceholderExpansion.java
@@ -63,7 +63,7 @@ public final class EzCountdownPlaceholderExpansion extends PlaceholderExpansion 
             case "hours" -> String.valueOf(parts.hours());
             case "minutes" -> String.valueOf(parts.minutes());
             case "seconds" -> String.valueOf(parts.seconds());
-            case "formatted" -> TimeFormat.format(parts);
+            case "formatted" -> TimeFormat.format(parts, manager.getTimeFormatConfig());
             default -> "";
         };
     }

--- a/src/main/java/com/skyblockexp/ezcountdown/listener/actions/GuiActionRegistry.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/listener/actions/GuiActionRegistry.java
@@ -29,7 +29,7 @@ public class GuiActionRegistry {
 
     public GuiActionRegistry(CountdownManager manager, MessageManager messageManager, ChatInputListener chatInputListener, Registry registry, EditorMenu editorMenu, DisplayEditor displayEditor, CommandsEditor commandsEditor) {
         this.openEditorAction = new OpenEditorAction(editorMenu);
-        this.previewAction = new PreviewCountdownAction(messageManager);
+        this.previewAction = new PreviewCountdownAction(messageManager, manager);
         this.deleteAction = new DeleteCountdownAction(manager, messageManager, registry);
         this.toggleRunningAction = new ToggleRunningAction(manager, messageManager);
         this.openDisplayEditorAction = new OpenDisplayEditorAction(displayEditor);

--- a/src/main/java/com/skyblockexp/ezcountdown/listener/actions/PreviewCountdownAction.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/listener/actions/PreviewCountdownAction.java
@@ -1,6 +1,7 @@
 package com.skyblockexp.ezcountdown.listener.actions;
 
 import com.skyblockexp.ezcountdown.api.model.Countdown;
+import com.skyblockexp.ezcountdown.manager.CountdownManager;
 import com.skyblockexp.ezcountdown.manager.MessageManager;
 import com.skyblockexp.ezcountdown.util.TimeFormat;
 import org.bukkit.entity.Player;
@@ -11,9 +12,11 @@ import java.util.Optional;
 
 public class PreviewCountdownAction implements GuiAction {
     private final MessageManager messageManager;
+    private final CountdownManager countdownManager;
 
-    public PreviewCountdownAction(MessageManager messageManager) {
+    public PreviewCountdownAction(MessageManager messageManager, CountdownManager countdownManager) {
         this.messageManager = messageManager;
+        this.countdownManager = countdownManager;
     }
 
     @Override
@@ -27,7 +30,7 @@ public class PreviewCountdownAction implements GuiAction {
             remaining = cd.getDurationSeconds();
         }
         var parts = TimeFormat.toParts(remaining);
-        String formatted = TimeFormat.format(parts);
+        String formatted = TimeFormat.format(parts, countdownManager.getTimeFormatConfig());
         String message = cd.getFormatMessage()
                 .replace("{name}", cd.getName())
                 .replace("{days}", String.valueOf(parts.days()))

--- a/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/manager/CountdownManager.java
@@ -52,6 +52,7 @@ public final class CountdownManager {
     private final java.util.concurrent.ConcurrentHashMap<String, Instant> lastEndAt = new java.util.concurrent.ConcurrentHashMap<>();
 
     private BukkitTask task;
+    private volatile TimeFormat.FormatConfig timeFormatConfig = TimeFormat.FormatConfig.DEFAULT;
 
     public CountdownManager(Registry registry,
                             DiscordWebhookConfig discordWebhookConfig,
@@ -66,6 +67,14 @@ public final class CountdownManager {
         this.messageManager = Objects.requireNonNull(messageManager, "messageManager");
         this.locationManager = Objects.requireNonNull(locationManager, "locationManager");
         // discordWebhookConfig provided by bootstrap
+    }
+
+    public void setTimeFormatConfig(TimeFormat.FormatConfig config) {
+        this.timeFormatConfig = Objects.requireNonNull(config, "config");
+    }
+
+    public TimeFormat.FormatConfig getTimeFormatConfig() {
+        return timeFormatConfig;
     }
 
     public void load() {
@@ -412,7 +421,7 @@ public final class CountdownManager {
 
     private String buildMessage(Countdown countdown, long remaining) {
         TimeParts parts = TimeFormat.toParts(remaining);
-        String formatted = TimeFormat.format(parts);
+        String formatted = TimeFormat.format(parts, timeFormatConfig);
         String message = countdown.getFormatMessage();
         message = message.replace("{name}", countdown.getName())
                 .replace("{days}", String.valueOf(parts.days()))
@@ -568,7 +577,7 @@ public final class CountdownManager {
             remaining = Math.max(0L, countdown.getTargetInstant().getEpochSecond() - java.time.Instant.now().getEpochSecond());
         }
         TimeParts parts = TimeFormat.toParts(remaining);
-        out = out.replace("{time_left}", TimeFormat.format(parts));
+        out = out.replace("{time_left}", TimeFormat.format(parts, timeFormatConfig));
         out = out.replace("{days}", String.valueOf(parts.days()));
         out = out.replace("{hours}", String.valueOf(parts.hours()));
         out = out.replace("{minutes}", String.valueOf(parts.minutes()));

--- a/src/main/java/com/skyblockexp/ezcountdown/util/TimeFormat.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/util/TimeFormat.java
@@ -36,6 +36,7 @@ public final class TimeFormat {
      * least the last segment is always kept.
      */
     public static String format(TimeParts parts, FormatConfig config) {
+        if (config == null) config = FormatConfig.DEFAULT;
         String pattern = (config.pattern() == null || config.pattern().isBlank())
                 ? DEFAULT_PATTERN : config.pattern();
         if (!config.hideLeadingZeros()) {

--- a/src/main/java/com/skyblockexp/ezcountdown/util/TimeFormat.java
+++ b/src/main/java/com/skyblockexp/ezcountdown/util/TimeFormat.java
@@ -2,6 +2,8 @@ package com.skyblockexp.ezcountdown.util;
 
 public final class TimeFormat {
 
+    public static final String DEFAULT_PATTERN = "{days}d {hours}h {minutes}m {seconds}s";
+
     private TimeFormat() {
     }
 
@@ -16,10 +18,67 @@ public final class TimeFormat {
         return new TimeParts(days, hours, minutes, seconds);
     }
 
+    /**
+     * Formats using the default pattern with no leading-zero suppression.
+     * Kept for backward compatibility.
+     */
     public static String format(TimeParts parts) {
-        return parts.days() + "d " + parts.hours() + "h " + parts.minutes() + "m " + parts.seconds() + "s";
+        return format(parts, FormatConfig.DEFAULT);
+    }
+
+    /**
+     * Formats {@code parts} according to the given {@link FormatConfig}.
+     * <p>
+     * The pattern supports the tokens {@code {days}}, {@code {hours}},
+     * {@code {minutes}}, {@code {seconds}}.  When
+     * {@link FormatConfig#hideLeadingZeros()} is {@code true}, leading
+     * space-delimited segments whose unit value is zero are omitted, but at
+     * least the last segment is always kept.
+     */
+    public static String format(TimeParts parts, FormatConfig config) {
+        String pattern = (config.pattern() == null || config.pattern().isBlank())
+                ? DEFAULT_PATTERN : config.pattern();
+        if (!config.hideLeadingZeros()) {
+            return pattern
+                    .replace("{days}", String.valueOf(parts.days()))
+                    .replace("{hours}", String.valueOf(parts.hours()))
+                    .replace("{minutes}", String.valueOf(parts.minutes()))
+                    .replace("{seconds}", String.valueOf(parts.seconds()));
+        }
+        // Split on spaces; drop leading segments whose single unit value is 0.
+        String[] segments = pattern.split(" ");
+        String[] tokens = {"{days}", "{hours}", "{minutes}", "{seconds}"};
+        long[] values = {parts.days(), parts.hours(), parts.minutes(), parts.seconds()};
+        boolean leading = true;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.length; i++) {
+            String seg = segments[i];
+            boolean skip = false;
+            if (leading && i < segments.length - 1) {
+                for (int u = 0; u < tokens.length; u++) {
+                    if (seg.contains(tokens[u]) && values[u] == 0) {
+                        skip = true;
+                        break;
+                    }
+                }
+            }
+            if (skip) continue;
+            leading = false;
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(seg);
+        }
+        return sb.toString()
+                .replace("{days}", String.valueOf(parts.days()))
+                .replace("{hours}", String.valueOf(parts.hours()))
+                .replace("{minutes}", String.valueOf(parts.minutes()))
+                .replace("{seconds}", String.valueOf(parts.seconds()));
     }
 
     public record TimeParts(long days, long hours, long minutes, long seconds) {
+    }
+
+    public record FormatConfig(String pattern, boolean hideLeadingZeros) {
+        /** Default: full pattern, no leading-zero suppression (preserves old behaviour). */
+        public static final FormatConfig DEFAULT = new FormatConfig(DEFAULT_PATTERN, false);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,13 @@ display:
     bossbar-ticks: 1
     # How often the scoreboard sidebar is refreshed, in ticks. Minimum is 1.
     scoreboard-ticks: 1
+  time-format:
+    # Template used for the {formatted} / %ezcountdown_<name>_formatted% placeholder.
+    # Supported tokens: {days}, {hours}, {minutes}, {seconds}
+    pattern: "{days}d {hours}h {minutes}m {seconds}s"
+    # When true, leading units whose value is 0 are hidden.
+    # Example: 0d 2h 5m 3s becomes  2h 5m 3s
+    hide-leading-zeros: true
 
 display-overrides:
   # Set to true to force-enable a display type even if runtime checks fail.

--- a/src/test/java/com/skyblockexp/ezcountdown/util/TimeFormatTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/util/TimeFormatTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TimeFormatTest {
 
+    // ── legacy format(TimeParts) — no hiding ────────────────────────────────
+
     @Test
     public void zeroSeconds() {
         TimeFormat.TimeParts parts = TimeFormat.toParts(0);
@@ -44,5 +46,66 @@ public class TimeFormatTest {
         assertEquals(0, parts.hours());
         assertEquals(0, parts.minutes());
         assertEquals(0, parts.seconds());
+    }
+
+    // ── format(TimeParts, FormatConfig) with hideLeadingZeros = false ───────
+
+    @Test
+    public void formatConfig_hideLeadingZerosFalse_keepsLeadingZeros() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", false);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(3661); // 0d 1h 1m 1s
+        assertEquals("0d 1h 1m 1s", TimeFormat.format(parts, config));
+    }
+
+    // ── format(TimeParts, FormatConfig) with hideLeadingZeros = true ────────
+
+    @Test
+    public void hideLeadingZeros_daysAndHoursZero_showsMinutesSeconds() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", true);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(5 * 60 + 3); // 0d 0h 5m 3s
+        assertEquals("5m 3s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void hideLeadingZeros_onlyDaysZero_showsHoursOnward() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", true);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(2 * 3600 + 30 * 60 + 15); // 0d 2h 30m 15s
+        assertEquals("2h 30m 15s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void hideLeadingZeros_allZeroExceptSeconds_showsSeconds() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", true);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(45); // 0d 0h 0m 45s
+        assertEquals("45s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void hideLeadingZeros_allZero_showsZeroSeconds() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", true);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(0); // 0d 0h 0m 0s
+        assertEquals("0s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void hideLeadingZeros_nothingToHide_returnsFull() {
+        var config = new TimeFormat.FormatConfig("{days}d {hours}h {minutes}m {seconds}s", true);
+        long total = 2L * 86400 + 5 * 3600 + 3 * 60 + 7;
+        TimeFormat.TimeParts parts = TimeFormat.toParts(total); // 2d 5h 3m 7s
+        assertEquals("2d 5h 3m 7s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void hideLeadingZeros_customPattern_worksCorrectly() {
+        var config = new TimeFormat.FormatConfig("{hours}h {minutes}m {seconds}s", true);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(3 * 60 + 22); // 0h 3m 22s
+        assertEquals("3m 22s", TimeFormat.format(parts, config));
+    }
+
+    @Test
+    public void nullOrBlankPattern_fallsBackToDefault() {
+        var config = new TimeFormat.FormatConfig(null, false);
+        TimeFormat.TimeParts parts = TimeFormat.toParts(3661);
+        assertEquals("0d 1h 1m 1s", TimeFormat.format(parts, config));
     }
 }


### PR DESCRIPTION
- **Configurable time format** — new `display.time-format` section in `config.yml`.
  - `pattern` (default `"{days}d {hours}h {minutes}m {seconds}s"`) — customize the token layout used for the `{formatted}` placeholder and `%ezcountdown_<name>_formatted%` PAPI expansion.
  - `hide-leading-zeros` (default `true`) — when enabled, leading space-delimited segments whose unit value is zero are suppressed. For example, `0d 0h 5m 3s` is displayed as `5m 3s`.
  - Applies to countdown display messages, discord webhook `{time_left}`, PlaceholderAPI, and the GUI preview action.
  - Hot-reloads with `/countdown reload`.