### PR TITLE
release: bump to 2.0.2 and add placeholder hide-leading-zeros tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-07-07
+
+### Added
+
+- **Placeholder formatted output regression tests** - added unit coverage in `EzCountdownPlaceholderExpansionUnitTest` to verify `%ezcountdown_<name>_formatted%` honors `display.time-format.hide-leading-zeros` for both enabled and disabled configurations.
+
 ## [2.0.1] - 2026-05-22
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezcountdown</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>EzCountdown Plugin</name>
     <description>Configurable countdowns for server launches, events, and maintenance windows.</description>
     <packaging>jar</packaging>

--- a/src/test/java/com/skyblockexp/ezcountdown/integration/placeholder/EzCountdownPlaceholderExpansionUnitTest.java
+++ b/src/test/java/com/skyblockexp/ezcountdown/integration/placeholder/EzCountdownPlaceholderExpansionUnitTest.java
@@ -4,6 +4,7 @@ import com.skyblockexp.ezcountdown.api.model.Countdown;
 import com.skyblockexp.ezcountdown.api.model.CountdownType;
 import com.skyblockexp.ezcountdown.integration.placeholder.EzCountdownPlaceholderExpansion;
 import com.skyblockexp.ezcountdown.test.MockBukkitTestBase;
+import com.skyblockexp.ezcountdown.util.TimeFormat;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -31,5 +32,50 @@ public class EzCountdownPlaceholderExpansionUnitTest extends MockBukkitTestBase 
         String seconds = expansion.onPlaceholderRequest(null, "ph-test_seconds");
         assertNotNull(seconds);
         assertTrue(Integer.parseInt(seconds) >= 0);
+    }
+
+    @Test
+    public void onPlaceholderRequest_formatted_hidesLeadingZeroDaysAndHours_whenConfigured() {
+        registry.countdowns().setTimeFormatConfig(new TimeFormat.FormatConfig(
+                "{days}d {hours}h {minutes}m {seconds}s", true
+        ));
+
+        Countdown cd = new Countdown("ph-hide", CountdownType.DURATION,
+                java.util.EnumSet.noneOf(com.skyblockexp.ezcountdown.display.DisplayType.class),
+                1, null, "{formatted}", null, null, java.util.List.of(), ZoneId.systemDefault());
+        cd.setDurationSeconds(65);
+        cd.setRunning(true);
+        cd.setTargetInstant(Instant.now().plusSeconds(65));
+        registry.countdowns().createCountdown(cd);
+
+        EzCountdownPlaceholderExpansion expansion = new EzCountdownPlaceholderExpansion(registry);
+        String formatted = expansion.onPlaceholderRequest(null, "ph-hide_formatted");
+
+        assertNotNull(formatted);
+        assertFalse(formatted.isEmpty());
+        assertFalse(formatted.contains("d"));
+        assertFalse(formatted.contains("h"));
+    }
+
+    @Test
+    public void onPlaceholderRequest_formatted_keepsLeadingZeroDaysAndHours_whenDisabled() {
+        registry.countdowns().setTimeFormatConfig(new TimeFormat.FormatConfig(
+                "{days}d {hours}h {minutes}m {seconds}s", false
+        ));
+
+        Countdown cd = new Countdown("ph-show", CountdownType.DURATION,
+                java.util.EnumSet.noneOf(com.skyblockexp.ezcountdown.display.DisplayType.class),
+                1, null, "{formatted}", null, null, java.util.List.of(), ZoneId.systemDefault());
+        cd.setDurationSeconds(65);
+        cd.setRunning(true);
+        cd.setTargetInstant(Instant.now().plusSeconds(65));
+        registry.countdowns().createCountdown(cd);
+
+        EzCountdownPlaceholderExpansion expansion = new EzCountdownPlaceholderExpansion(registry);
+        String formatted = expansion.onPlaceholderRequest(null, "ph-show_formatted");
+
+        assertNotNull(formatted);
+        assertFalse(formatted.isEmpty());
+        assertTrue(formatted.startsWith("0d 0h "));
     }
 }


### PR DESCRIPTION
**Placeholder formatted output regression tests** - added unit coverage in `EzCountdownPlaceholderExpansionUnitTest` to verify `%ezcountdown_<name>_formatted%` honors `display.time-format.hide-leading-zeros` for both enabled and disabled configurations.